### PR TITLE
resolve syntax error in type 'ipconfig'

### DIFF
--- a/spec/unit/puppet/type/ipconfig.rb
+++ b/spec/unit/puppet/type/ipconfig.rb
@@ -9,3 +9,4 @@ describe Puppet::Type.type(:ipconfig) do
       Puppet::Type.type(:ipconfig).new(:name => '')
     }.to raise_error(Puppet::Error, /Name must not be empty/)
   end
+end


### PR DESCRIPTION
addresses:

```
ParserSyntaxError: syntax error in
`modules/puppet-windowsnetwork/spec/unit/puppet/type/ipconfig.rb`:(11,6):
syntax error, unexpected $end, expecting keyword_end
```

Signed-off-by: Paul Morgan jumanjiman@gmail.com
