### PR TITLE
fix setdnsdomain method parameter typo (illegal parameter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ ipconfig {'Local Area Connection':
       netbios                     => 'enabled',
       dns                         => ['8.8.8.8','8.8.4.4'],
       dnsdomainsuffixsearchorder  => ['example.com','example2.com'],
-      dnshostname                 => 'example.com'
+      dnsdomain                   => 'example.com'
 ```

--- a/lib/puppet/provider/ipconfig/ipconfig.rb
+++ b/lib/puppet/provider/ipconfig/ipconfig.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:ipconfig).provide(:ipconfig, :parent => Puppet::Provider::Win
     #deviceid_esc=@deviceid.gsub('\\','\\\\\\') # wonky escaping needed.
     #adapters=wmi_exec_adapter(my_wmi, deviceid_esc)
 
-    # this needs to be DRYed up to just wmi_exec_assoc 
+    # this needs to be DRYed up to just wmi_exec_assoc
     # disabled deviceid based namevar and moved to human friendly
     # netconnectionid
 
@@ -131,16 +131,16 @@ Puppet::Type.type(:ipconfig).provide(:ipconfig, :parent => Puppet::Provider::Win
     end
   end
 
-  def dnshostname
+  def dnsdomain
     dnssuffixes ||= Array.new
     enum_netconn do |netconnectionid|
-      return netconnectionid.DNSHostName
+      return netconnectionid.DNSDomain
     end
   end
 
-  def dnshostname=newvalue
+  def dnsdomain=newvalue
     enum_netconn do |netconnectionid|
-      setdnsdomain(netconnectionid,@resource[:dnshostname])
+      setdnsdomain(netconnectionid,@resource[:dnsdomain])
     end
   end
 
@@ -193,7 +193,7 @@ Puppet::Type.type(:ipconfig).provide(:ipconfig, :parent => Puppet::Provider::Win
     self.dnsregister = @resource[:dnsregister]
     self.netbios = @resource[:netbios]
     self.dnsdomainsuffixsearchorder = @resource[:dnsdomainsuffixsearchorder]
-    self.dnshostname = @resource[:dnshostname]
+    self.dnsdomain = @resource[:dnsdomain]
     true
   end
 

--- a/lib/puppet/provider/winnetwork.rb
+++ b/lib/puppet/provider/winnetwork.rb
@@ -63,10 +63,10 @@ class Puppet::Provider::Winnetwork < Puppet::Provider
     oOutParam = adapter.ExecMethod_("SetDNSSuffixSearchOrder", oInParam)
   end
 
-  def setdnsdomain(adapter,dnshostname)
+  def setdnsdomain(adapter,dnsdomain)
     oMethod = adapter.Methods_("SetDNSDomain")
     oInParam = oMethod.InParameters.SpawnInstance_()
-    oInParam.DNSHostName = dnshostname
+    oInParam.DNSDomain = dnsdomain
     oOutParam = adapter.ExecMethod_("SetDNSDomain", oInParam)
   end
 

--- a/lib/puppet/type/ipconfig.rb
+++ b/lib/puppet/type/ipconfig.rb
@@ -36,7 +36,7 @@ Puppet::Type.newtype(:ipconfig) do
     desc 'Append these DNS Suffixes'
   end
 
-  newproperty(:dnshostname) do
+  newproperty(:dnsdomain) do
     desc 'DNS Suffix for this connection'
   end
 

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -9,5 +9,5 @@ ipconfig {'Local Area Connection':
       netbios                     => 'enabled',
       dns                         => ['8.8.8.8','8.8.4.4'],
       dnsdomainsuffixsearchorder  => ['example.com','example2.com'],
-      dnshostname                 => 'example.com'
+      dnsdomain                   => 'example.com'
 }


### PR DESCRIPTION
http://msdn.microsoft.com/en-us/library/windows/desktop/aa393294(v=vs.85).aspx
states the argument is DNSDomain

All references to the illegal parameter were modified to align with the actual
DNSDomain type (string)
