### PR TITLE
call .lines.to_a instead of .to_a on gwcostmetric for ruby 1.9 compatibi...

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'rismoney-puppet-windowsnetwork'
-version '0.0.1'
+version '0.0.2'
 source 'git@github.com:rismoney/puppet-windowsnetwork.git'
 author 'rismoney'
 license 'TBD'

--- a/lib/puppet/provider/winnetwork.rb
+++ b/lib/puppet/provider/winnetwork.rb
@@ -46,7 +46,7 @@ class Puppet::Provider::Winnetwork < Puppet::Provider
     oMethod = adapter.Methods_("SetGateways")
     oInParam = oMethod.InParameters.SpawnInstance_()
     oInParam.DefaultIPGateway = gateways_hash[:defaultgateway]
-    oInParam.GatewayCostMetric = gateways_hash[:gwcostmetric].to_a
+    oInParam.GatewayCostMetric = gateways_hash[:gwcostmetric].lines.to_a
     oOutParam = adapter.ExecMethod_("SetGateways", oInParam)
   end
 


### PR DESCRIPTION
The `setgateways` method in the `winnetwork` provider calls `.to_a on` a string.

```
 oInParam.GatewayCostMetric = gateways_hash[:gwcostmetric].to_a
```

For ruby 1.9 and newer versions of puppet enterprise this should be changed to `.lines.to_a`.

```
 oInParam.GatewayCostMetric = gateways_hash[:gwcostmetric].lines.to_a
```
